### PR TITLE
Add table of limit positions, refactor tables code

### DIFF
--- a/src/api/getLimitPositions.ts
+++ b/src/api/getLimitPositions.ts
@@ -1,0 +1,59 @@
+import axios from 'axios';
+import { createUrl, getAxiosHeaderParam } from './utils';
+
+type PositionResponse = {
+    orderId: 431039236;
+    symbol: string;
+    status: string;
+    clientOrderId: string;
+    price: string;
+    avgPrice: string;
+    origQty: string;
+    executedQty: string;
+    cumQuote: string;
+    timeInForce: string;
+    type: string;
+    reduceOnly: boolean;
+    closePosition: boolean;
+    side: 'SELL' | 'BUY';
+    positionSide: string;
+    stopPrice: string;
+    workingType: string;
+    priceProtect: boolean;
+    origType: string;
+    priceMatch: string;
+    selfTradePreventionMode: string;
+    goodTillDate: number;
+    time: number;
+    updateTime: number;
+};
+
+export type LimitPosition = Pick<
+    PositionResponse,
+    'symbol' | 'price' | 'origQty' | 'executedQty' | 'type' | 'side' | 'time'
+>;
+
+export const getLimitPositions = () => {
+    const params = {
+        symbol: 'bnbusdt',
+        timestamp: Date.now()
+    };
+    const url = createUrl('/fapi/v1/openOrders', params);
+
+    return axios
+        .get<PositionResponse[]>(url, getAxiosHeaderParam())
+        .then(({ data }) =>
+            data.map(
+                ({ symbol, executedQty, origQty, price, side, time, type }) =>
+                    <LimitPosition>{
+                        symbol,
+                        executedQty,
+                        origQty,
+                        price,
+                        side,
+                        time,
+                        type
+                    }
+            )
+        );
+};

--- a/src/components/Positions/components/LimitPositionRow.tsx
+++ b/src/components/Positions/components/LimitPositionRow.tsx
@@ -1,0 +1,40 @@
+import { twMerge } from 'tailwind-merge';
+
+import { LimitPosition } from '../../../api/getLimitPositions';
+import { parseStringToFixed } from '../../../utils/parseStringToFixed';
+
+type Props = {
+    position: LimitPosition;
+};
+
+export const LimitPositionRow = ({ position }: Props) => {
+    const { executedQty, origQty, price, side, symbol, time, type } = position;
+    const formattedData = {
+        time: new Date(time).toLocaleString(),
+        symbol,
+        type,
+        side,
+        price: parseStringToFixed(price),
+        amount: parseStringToFixed(String(+origQty * +price)),
+        filled: executedQty
+    };
+    const classesFor = (side: 'SELL' | 'BUY') =>
+        twMerge(
+            side === 'BUY' && 'text-green-500',
+            side === 'SELL' && 'text-red-500'
+        );
+
+    return (
+        <tr className="text-center odd:bg-slate-50 even:bg-slate-100">
+            <td>{formattedData.time}</td>
+            <td>{formattedData.symbol}</td>
+            <td>{formattedData.type}</td>
+            <td className={classesFor(formattedData.side)}>
+                {formattedData.side}
+            </td>
+            <td>{formattedData.price}</td>
+            <td>{formattedData.amount}</td>
+            <td>{formattedData.filled}</td>
+        </tr>
+    );
+};

--- a/src/components/Positions/components/LimitPositionsTable.tsx
+++ b/src/components/Positions/components/LimitPositionsTable.tsx
@@ -1,0 +1,33 @@
+import { Loading } from '../../Loading/Loading';
+import { LimitPositionRow } from './LimitPositionRow';
+
+import { LimitPosition } from '../../../api/getLimitPositions';
+
+type Props = { positions?: LimitPosition[] };
+
+export const LimitPositionsTable = ({ positions }: Props) => {
+    if (!positions) {
+        return <Loading />;
+    }
+
+    return (
+        <table className="h-ful w-full table-fixed border-t-[1px] border-black">
+            <thead className="sticky top-0 border-b-2 border-slate-200 bg-slate-100">
+                <tr>
+                    <th>Time</th>
+                    <th>Symbol</th>
+                    <th>Type</th>
+                    <th>Side</th>
+                    <th>Price</th>
+                    <th>Amount</th>
+                    <th>Filled</th>
+                </tr>
+            </thead>
+            <tbody>
+                {positions.map((p) => (
+                    <LimitPositionRow key={p.time} position={p} />
+                ))}
+            </tbody>
+        </table>
+    );
+};

--- a/src/components/Positions/components/PositionRow.tsx
+++ b/src/components/Positions/components/PositionRow.tsx
@@ -1,26 +1,36 @@
-import { Position } from '../../../api/getPositions';
+import { twMerge } from 'tailwind-merge';
+
 import { parseStringToFixed } from '../../../utils/parseStringToFixed';
+
+import { Position } from '../../../api/getPositions';
 
 type Props = {
     position: Position;
 };
 
 export const PositionRow = ({ position }: Props) => {
-    console.log(position.unRealizedProfit);
+    const { entryPrice, markPrice, positionAmt, symbol, unRealizedProfit } =
+        position;
+
+    const transformedData: { [key in keyof typeof position]: string } = {
+        entryPrice: parseStringToFixed(entryPrice),
+        markPrice: parseStringToFixed(markPrice),
+        unRealizedProfit: parseStringToFixed(unRealizedProfit),
+        positionAmt,
+        symbol
+    };
+
+    const classesFor = (profit: string) =>
+        twMerge(Number(profit) > 0 ? 'text-green-500' : 'text-red-500');
+
     return (
         <tr className="text-center odd:bg-slate-50 even:bg-slate-100">
-            <td>{position.symbol}</td>
-            <td>{position.positionAmt}</td>
-            <td>{parseStringToFixed(position.entryPrice)}</td>
-            <td>{parseStringToFixed(position.markPrice)}</td>
-            <td
-                className={
-                    position.unRealizedProfit > '0'
-                        ? 'text-green-500'
-                        : 'text-red-500'
-                }
-            >
-                {parseStringToFixed(position.unRealizedProfit)}
+            <td>{transformedData.symbol}</td>
+            <td>{transformedData.positionAmt}</td>
+            <td>{transformedData.entryPrice}</td>
+            <td>{transformedData.markPrice}</td>
+            <td className={classesFor(transformedData.unRealizedProfit)}>
+                {transformedData.unRealizedProfit}
             </td>
         </tr>
     );

--- a/src/components/Positions/components/PositionsTable.tsx
+++ b/src/components/Positions/components/PositionsTable.tsx
@@ -1,9 +1,15 @@
-import { Position } from '../../../api/getPositions';
+import { Loading } from '../../Loading/Loading';
 import { PositionRow } from './PositionRow';
 
-type Props = { positions: Position[] };
+import { Position } from '../../../api/getPositions';
 
-export const PositionTable = ({ positions }: Props) => {
+type Props = { positions?: Position[] };
+
+export const PositionsTable = ({ positions }: Props) => {
+    if (!positions) {
+        return <Loading />;
+    }
+
     return (
         <table className="h-ful w-full table-fixed border-t-[1px] border-black">
             <thead className="sticky top-0 border-b-2 border-slate-200 bg-slate-100">

--- a/src/components/Positions/components/Tabs.tsx
+++ b/src/components/Positions/components/Tabs.tsx
@@ -1,0 +1,33 @@
+import { twMerge } from 'tailwind-merge';
+
+import { slideType } from '..';
+
+type Props = {
+    showOrders: VoidFunction;
+    showPositions: VoidFunction;
+    openedSlide: keyof typeof slideType;
+};
+
+export const Tabs = ({ showOrders, showPositions, openedSlide }: Props) => {
+    const classesFor = (type: keyof typeof slideType) =>
+        twMerge(
+            type === openedSlide && 'font-bold bg-red-100',
+            'hover:cursor-pointer h-full flex justify-center items-center w-28 '
+        );
+    return (
+        <div className="flex h-8 w-full  divide-slate-400 border-b-[1px]">
+            <div
+                className={classesFor(slideType.positions)}
+                onClick={showPositions}
+            >
+                Positions
+            </div>
+            <div
+                className={classesFor(slideType.openOrders)}
+                onClick={showOrders}
+            >
+                Open Orders
+            </div>
+        </div>
+    );
+};

--- a/src/components/Positions/index.tsx
+++ b/src/components/Positions/index.tsx
@@ -1,18 +1,50 @@
-import { getPositions } from '../../api/getPositions';
+import { ReactNode, useState } from 'react';
+import { PositionsTable } from './components/PositionsTable';
+import { Tabs } from './components/Tabs';
 import { usePolling } from '../../hooks/usePolling';
-import { Loading } from '../Loading/Loading';
-import { PositionTable } from './components/PositionTable';
+import { getPositions } from '../../api/getPositions';
+import { getLimitPositions } from '../../api/getLimitPositions';
+import { LimitPositionsTable } from './components/LimitPositionsTable';
+
+export const slideType = {
+    positions: 'positions',
+    openOrders: 'openOrders'
+} as const;
 
 export const Positions = () => {
-    const { data, error } = usePolling(getPositions);
+    const [slide, setSlide] = useState<keyof typeof slideType>(
+        slideType.positions
+    );
 
-    if (error) {
+    const { data: positions, error: positionsError } = usePolling(getPositions);
+    const { data: limitPositions, error: limitPositionsError } =
+        usePolling(getLimitPositions);
+
+    if (positionsError || limitPositionsError) {
         throw new Error('Error on get position request');
     }
 
-    if (!data) {
-        return <Loading />;
-    }
+    const showOrders = () => {
+        setSlide(slideType.openOrders);
+    };
 
-    return <PositionTable positions={data} />;
+    const showPositions = () => {
+        setSlide(slideType.positions);
+    };
+
+    const tables: { [key in keyof typeof slideType]: ReactNode } = {
+        openOrders: <LimitPositionsTable positions={limitPositions} />,
+        positions: <PositionsTable positions={positions} />
+    };
+
+    return (
+        <div className="flex h-full w-full flex-col items-start ">
+            <Tabs
+                showOrders={showOrders}
+                showPositions={showPositions}
+                openedSlide={slide}
+            />
+            {tables[slide]}
+        </div>
+    );
 };


### PR DESCRIPTION
Заметил, что открытые лимитные позиции не приходят с /fapi/v2/positionRisk. 
Добавил вкладку для отображения лимиток. Немного отрефакторил код, касающийся таблиц. Интересно будет услышать отзыв о таком подходе, при котором из jsx максимально выносится вся логика. 